### PR TITLE
switch interface to use a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,19 @@ using ffmpeg.
     var min = 1.0;
     var max = -1.0;
     
-    pcm.getPcmData('test.mp3', {},
-      function(sample, channel) {
+    var pcmStream = pcm.getPcmData('test.mp3')
+    
+    pcmStream
+      .on('data', function(sample, channel) {
         // Sample is from [-1.0...1.0], channel is 0 for left and 1 for right
         min = Math.min(min, sample);
         max = Math.max(max, sample);
-      },
-      function(err, output) {
+      })
+      .on('end', function(err, output) {
         if (err)
           throw new Error(err);
         console.log('min=' + min + ', max=' + max);
-      }
-    );
+      })
 
 ## Sponsors ##
 

--- a/example.js
+++ b/example.js
@@ -1,0 +1,18 @@
+var pcm = require('pcm');
+
+var min = 1.0;
+var max = -1.0;
+
+var pcmStream = pcm.getPcmData('test.mp3')
+
+pcmStream
+  .on('data', function(sample, channel) {
+    // Sample is from [-1.0...1.0], channel is 0 for left and 1 for right
+    min = Math.min(min, sample);
+    max = Math.max(max, sample);
+  })
+  .on('end', function(err, output) {
+    if (err)
+      throw new Error(err);
+    console.log('min=' + min + ', max=' + max);
+  })

--- a/lib/pcm.js
+++ b/lib/pcm.js
@@ -1,22 +1,20 @@
 var spawn = require('child_process').spawn;
+var stream = require('stream');
 
 /**
- * Takes a file containing an audio stream and returns raw PCM data
- * asynchronously using ffmpeg.
+ * Takes a file containing an audio stream and returns a stream that
+ * will emit raw PCM data asynchronously using ffmpeg.
  * @param {String} filename file to extract audio from.
  * @param {Object} options placeholder, currently unused.
- * @param {Function} sampleCallback(sample, channel) called each time a sample
- *        is read. sample ranges from [-1.0...1.0] and channel is 0 for left
- *        channel, 1 for right channel.
- * @param {Function} endCallback(err, output) called when all samples have been
- *        read or an error occurred. err is the ffmpeg error output or null, 
- *        output is the ffmpeg output on success.
  */
-exports.getPcmData = function(filename, options, sampleCallback, endCallback) {
+exports.getPcmData = function(filename, options) {
   var outputStr = '';
   var oddByte = null;
   var channel = 0;
   var gotData = false;
+  var sampleStream = new stream.Stream();
+  sampleStream.writeable = true;
+  sampleStream.readable = true;
   
   // Extract signed 16-bit little endian PCM data with ffmpeg and pipe to
   // stdout
@@ -33,13 +31,13 @@ exports.getPcmData = function(filename, options, sampleCallback, endCallback) {
     // first byte from this block
     if (oddByte !== null) {
       value = ((data.readInt8(i++) << 8) | oddByte) / 32767;
-      sampleCallback(value, channel);
+      sampleStream.emit('data', value, channel);
       channel = ++channel % 2;
     }
     
     for (; i < data.length; i += 2) {
       value = data.readInt16LE(i) / 32767;
-      sampleCallback(value, channel);
+      sampleStream.emit('data', value, channel);
       channel = ++channel % 2;
     }
     
@@ -53,8 +51,10 @@ exports.getPcmData = function(filename, options, sampleCallback, endCallback) {
   
   ffmpeg.stderr.on('end', function() {
     if (gotData)
-      endCallback(null, outputStr);
+      sampleStream.emit('end', null, outputStr);
     else
-      endCallback(outputStr, null);
+      sampleStream.emit('end', outputStr, null);
   });
+  
+  return sampleStream;
 };


### PR DESCRIPTION
i think the error should be returned only in .on('error') and not in .on('data') but other than that this is pretty straightforward

it would also be cool to have getPcmData accept a stream as input
