### PR TITLE
Global variable leak in the ffmpeg data callback

### DIFF
--- a/lib/pcm.js
+++ b/lib/pcm.js
@@ -36,6 +36,7 @@ exports.getPcmData = function(filename, options, sampleCallback, endCallback) {
   ffmpeg.stdout.on('data', function(data) {
     gotData = true;
     
+    var value;
     var i = 0;
     var dataLen = data.length;
     


### PR DESCRIPTION
My client-code mocha tests picked up this little bugbear. Thanks for adding stream support, by the way - I'd hacked something together earlier but it was a bit uglier, plus now I don't have to run on a fork.
