### PR TITLE
Support for custom FFMPEG path

### DIFF
--- a/lib/pcm.js
+++ b/lib/pcm.js
@@ -27,10 +27,13 @@ exports.getPcmData = function(filename, options, sampleCallback, endCallback) {
   var sampleRate = 44100;
   if (typeof options.sampleRate !== 'undefined')
     sampleRate = options.sampleRate;
+  var ffmpegPath = 'ffmpeg';
+  if (typeof options.ffmpegPath !== 'undefined')
+    ffmpegPath = options.ffmpegPath;
   
   // Extract signed 16-bit little endian PCM data with ffmpeg and pipe to
   // stdout
-  var ffmpeg = spawn('ffmpeg', ['-i',filename,'-f','s16le','-ac',channels,
+  var ffmpeg = spawn(ffmpegPath, ['-i',filename,'-f','s16le','-ac',channels,
     '-acodec','pcm_s16le','-ar',sampleRate,'-y','pipe:1']);
   
   ffmpeg.stdout.on('data', function(data) {


### PR DESCRIPTION
Just a really simple change to the `options` object which allows users to specify a custom path to the FFMPEG executable.
This makes it possible to use this library alongside `@ffmpeg-installer/ffmpeg` (which is why I wrote this change and currently have to apply it with `patch-package` in my project).